### PR TITLE
Improved: Added support of product Store Id in preparing sendPath in send#SystemMessageSftp service

### DIFF
--- a/service/org/moqui/sftp/SftpMessageServices.xml
+++ b/service/org/moqui/sftp/SftpMessageServices.xml
@@ -46,11 +46,14 @@ along with this software (see the LICENSE.md file). If not, see
                 import java.sql.Timestamp
 
                 Timestamp msgDate = systemMessage.messageDate ?: systemMessage.initDate ?: ec.user.nowTimestamp
+
+                //NOTE: The service is customised to add the support of sftpUsername and productStoreId in sendPath for
+                //file name preparation when sending files to SFTP
                 String sendPath = ec.resource.expand(systemMessageType.sendPath, null,
                         [systemMessageId:systemMessage.systemMessageId, remoteMessageId:systemMessage.remoteMessageId,
                          systemMessageTypeId:systemMessage.systemMessageTypeId, systemMessageRemoteId:systemMessage.systemMessageRemoteId,
                          date:ec.l10n.format(msgDate, "yyyy-MM-dd"), dateTime:ec.l10n.format(msgDate, "yyyy-MM-dd-HH-mm-ss"),
-                         sftpUsername:systemMessageRemote.username], false)
+                         sftpUsername:systemMessageRemote.username, productStoreId:systemMessage.productStoreId], false)
                 String filename = systemMessage.remoteMessageId ?: systemMessage.systemMessageId
                 Charset charset = Charset.forName(systemMessageRemote.remoteCharset ?: "UTF-8")
 


### PR DESCRIPTION
This is done so that for the Feed Files preparing brand wise, we need to identify the reports for each brand/Product Store. So this will provide the support to use productStoreId in the file names if used in sendPath in the SystemMessage Types.