### PR TITLE
Improved: Added sftp username support to receive path and receive move path in poll#SystemMessageSftp service

### DIFF
--- a/service/org/moqui/sftp/SftpMessageServices.xml
+++ b/service/org/moqui/sftp/SftpMessageServices.xml
@@ -107,13 +107,15 @@ along with this software (see the LICENSE.md file). If not, see
                 import org.moqui.sftp.SftpClient
                 import java.nio.charset.Charset
 
+                //NOTE: The service is customised to add the support of sftpUsername in receivePath and receiveMovePath for
+                //file name preparation when sending files to SFTP
                 String receivePath = ec.resource.expand(systemMessageType.receivePath, null,
-                        [systemMessageTypeId:systemMessageTypeId, systemMessageRemoteId:systemMessageRemoteId], false)
+                        [systemMessageTypeId:systemMessageTypeId, systemMessageRemoteId:systemMessageRemoteId,sftpUsername:systemMessageRemote.username], false)
                 Charset charset = Charset.forName(systemMessageRemote.remoteCharset ?: "UTF-8")
                 String filePattern = systemMessageType.receiveFilePattern
                 String receiveResponseEnumId = systemMessageType.receiveResponseEnumId
                 String receiveMovePath = ec.resource.expand(systemMessageType.receiveMovePath, null,
-                        [systemMessageTypeId:systemMessageTypeId, systemMessageRemoteId:systemMessageRemoteId], false)
+                        [systemMessageTypeId:systemMessageTypeId, systemMessageRemoteId:systemMessageRemoteId,sftpUsername:systemMessageRemote.username], false)
 
                 // use SftpClient to put the file
                 String sftpHost = (String) systemMessageRemote.receiveUrl ?: (String) systemMessageRemote.sendUrl

--- a/service/org/moqui/sftp/SftpMessageServices.xml
+++ b/service/org/moqui/sftp/SftpMessageServices.xml
@@ -110,12 +110,12 @@ along with this software (see the LICENSE.md file). If not, see
                 //NOTE: The service is customised to add the support of sftpUsername in receivePath and receiveMovePath for
                 //file name preparation when sending files to SFTP
                 String receivePath = ec.resource.expand(systemMessageType.receivePath, null,
-                        [systemMessageTypeId:systemMessageTypeId, systemMessageRemoteId:systemMessageRemoteId,sftpUsername:systemMessageRemote.username], false)
+                        [systemMessageTypeId:systemMessageTypeId, systemMessageRemoteId:systemMessageRemoteId, sftpUsername:systemMessageRemote.username], false)
                 Charset charset = Charset.forName(systemMessageRemote.remoteCharset ?: "UTF-8")
                 String filePattern = systemMessageType.receiveFilePattern
                 String receiveResponseEnumId = systemMessageType.receiveResponseEnumId
                 String receiveMovePath = ec.resource.expand(systemMessageType.receiveMovePath, null,
-                        [systemMessageTypeId:systemMessageTypeId, systemMessageRemoteId:systemMessageRemoteId,sftpUsername:systemMessageRemote.username], false)
+                        [systemMessageTypeId:systemMessageTypeId, systemMessageRemoteId:systemMessageRemoteId, sftpUsername:systemMessageRemote.username], false)
 
                 // use SftpClient to put the file
                 String sftpHost = (String) systemMessageRemote.receiveUrl ?: (String) systemMessageRemote.sendUrl


### PR DESCRIPTION
1. SFTP username is  added to receive path and receive move path in poll#SystemMessageSftp service.
2. This will help in adding sftp username to file name preparation while we send files to SFTP.